### PR TITLE
add Intel Galileo to supported list

### DIFF
--- a/_includes/platform-support.html
+++ b/_includes/platform-support.html
@@ -7,7 +7,6 @@
             We support prototyping on 
             Raspberry Pi, 
             Pi 2, 
-            Pi 3, 
             Intel Galileo, 
             and 
             Beaglebone Black.

--- a/_includes/platform-support.html
+++ b/_includes/platform-support.html
@@ -7,6 +7,7 @@
             We support prototyping on 
             Raspberry Pi, 
             Pi 2, 
+            Intel Galileo, 
             and 
             Beaglebone Black.
         </div>

--- a/_includes/platform-support.html
+++ b/_includes/platform-support.html
@@ -7,6 +7,7 @@
             We support prototyping on 
             Raspberry Pi, 
             Pi 2, 
+            Pi 3, 
             Intel Galileo, 
             and 
             Beaglebone Black.

--- a/_includes/platform-support.html
+++ b/_includes/platform-support.html
@@ -4,7 +4,11 @@
         <img  height="80px" src="/images/beaglebone_icon.jpg"/>
         <img height="80px" src="/images/pi_logo.png"/>
         <div class="blurb">
-            We support prototyping on Raspberry Pi, Pi 2, and Beaglebone Black.
+            We support prototyping on 
+            Raspberry Pi, 
+            Pi 2, 
+            and 
+            Beaglebone Black.
         </div>
     </div>
 </div>


### PR DESCRIPTION
I also break everything up onto multiple lines, so that future platforms (and immediately the Pi 3) can be cleanly submitted in separate pull requests.  