### PR TITLE
Update mDNS and add MeteoStick

### DIFF
--- a/libraries.md
+++ b/libraries.md
@@ -48,7 +48,7 @@ The list separated in officially supported and community contributed projects.
 * **[hmc5883l](https://hex.pm/packages/hmc5883l)** - OTP application for reading
   the HMC5883L 3-axis magnetometer
 * **[Lifx](https://hex.pm/packages/lifx)** - A Client for [Lifx](http://lifx.com/) LAN API
-* **[mDNS](https://hex.pm/packages/mdns)** - A simple [mDNS](https://en.wikipedia.org/wiki/Multicast_DNS) (zeroconf, bonjour) client for device discovery on your local network.
+* **[mDNS](https://hex.pm/packages/mdns)** - A simple [mDNS](https://en.wikipedia.org/wiki/Multicast_DNS) (zeroconf, bonjour) server and client for device discovery on your local network.
 * **[MeteoStick](https://hex.pm/packages/meteo_stick)** - Client for communicating with the [MeteoStick](http://www.smartbedded.com/wiki/index.php/Meteostick) and [Fine Offset Weather Station](http://www.ambientweather.com/amws1000array.html)
 * **[Movi](https://hex.pm/packages/movi)** - A library for communicating with the [Audeme MOVI™ Voice Control Shield](http://www.audeme.com/movi.html)
 * **[nerves_io_neopixel](https://hex.pm/packages/nerves_io_neopixel)** -

--- a/libraries.md
+++ b/libraries.md
@@ -49,6 +49,7 @@ The list separated in officially supported and community contributed projects.
   the HMC5883L 3-axis magnetometer
 * **[Lifx](https://hex.pm/packages/lifx)** - A Client for [Lifx](http://lifx.com/) LAN API
 * **[mDNS](https://hex.pm/packages/mdns)** - A simple [mDNS](https://en.wikipedia.org/wiki/Multicast_DNS) (zeroconf, bonjour) client for device discovery on your local network.
+* **[MeteoStick](https://hex.pm/packages/meteo_stick)** - Client for communicating with the [MeteoStick](http://www.smartbedded.com/wiki/index.php/Meteostick) and [Fine Offset Weather Station](http://www.ambientweather.com/amws1000array.html)
 * **[Movi](https://hex.pm/packages/movi)** - A library for communicating with the [Audeme MOVI™ Voice Control Shield](http://www.audeme.com/movi.html)
 * **[nerves_io_neopixel](https://hex.pm/packages/nerves_io_neopixel)** -
   Drive WS2812B NeoPixel RGB LED strips from a Raspberry Pi


### PR DESCRIPTION
mDNS library now has server capability and added a new library for talking to a MeteoStick for weather station data.