### PR TITLE
Point to HexDocs supported hardware targets

### DIFF
--- a/index.md
+++ b/index.md
@@ -55,13 +55,11 @@ category: home
     <img width="80px" src="/images/pi_logo.png"/>
   </div>
   <div class="col-md-8">
-    The most popular prototyping boards are the Beaglebone Black and Raspberry Pi, Pi 2, and Pi 3.
+    <p>The most popular prototyping boards are the Beaglebone Black and Raspberry Pi family.</p>
+    <div class="row text-center">
+      <a class="btn btn-info btn-lg" href="https://hexdocs.pm/nerves/targets.html">
+        See All Supported Hardware
+      </a>
+    </div>
   </div>
 </div>
-
-<div class="row text-center">
-  <a class="btn btn-info btn-lg" href="https://github.com/nerves-project?utf8=%E2%9C%93&query=nerves_system_">
-    See All Hardware
-  </a>
-</div>
-


### PR DESCRIPTION
I think it's less confusing to point to the list of supported targets on HexDocs instead of linking to a search for all the system repositories on GitHub.

I'm also proposing that we pull the "Supported Hardware" button up closer to the text because I felt like it was weirdly outside the grid between the other two columns.

Before:
![image](https://cloud.githubusercontent.com/assets/69467/19176407/562a9266-8c0d-11e6-97b8-843993cf2bf3.png)

After:
![image](https://cloud.githubusercontent.com/assets/69467/19176398/4209d634-8c0d-11e6-94d6-424457d8e5ce.png)
