### PR TITLE
Update the nerves_init_gadget description

### DIFF
--- a/libraries.md
+++ b/libraries.md
@@ -18,7 +18,7 @@ hardware or add extra functionality to their systems.
 * **[nerves_firmware_ssh](https://hex.pm/packages/nerves_firmware_ssh)** -
   Over-the-air updates to Nerves devices using ssh
 * **[nerves_init_gadget](https://hex.pm/packages/nerves_init_gadget)** -
-  Easy Nerves initialization for devices with USB gadget interfaces
+  Simple initialization for devices running Nerves
 * **[nerves_network](https://github.com/nerves-project/nerves_network)** -
   Connect to wired and wireless networks on Nerves platforms
 * **[nerves_leds](https://hex.pm/packages/nerves_leds)** -


### PR DESCRIPTION
Use the description from nerves-project/nerves_init_gadget

I think this is a bit more clear as I found the mention of USB a bit misleading when I was looking for this package.